### PR TITLE
Public client: add Windows Broker support

### DIFF
--- a/azure_auth/handlers.py
+++ b/azure_auth/handlers.py
@@ -90,6 +90,20 @@ class AuthHandler:
                 ]
             return token_result
 
+    def wam_login(self) -> Optional[dict]:
+        """
+        Initiates the WAM login flow and returns the token result.
+        """
+        result = self.msal_app.acquire_token_interactive(
+            scopes=settings.AZURE_AUTH["SCOPES"],
+            prompt=settings.AZURE_AUTH.get("PROMPT", None),
+            parent_window_handle=msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE,
+        )
+        if "error" in result:
+            print(f"WAM login error: {result}")
+            result = None
+        return result
+
     def authenticate(self, token: dict) -> AbstractBaseUser:
         """
         Helper method to authenticate the user. Gets the Azure user from the

--- a/azure_auth/urls.py
+++ b/azure_auth/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.conf import settings
 
 from azure_auth.views import (
     azure_auth_callback,
@@ -10,7 +11,7 @@ from azure_auth.utils import is_broker_enabled
 
 app_name = "azure_auth"
 
-_login_function = azure_auth_login if not is_broker_enabled() else wam_auth_login
+_login_function = azure_auth_login if not is_broker_enabled(settings.AZURE_AUTH) else wam_auth_login
 urlpatterns = [
     path("login", _login_function, name="login"),
     path("logout", azure_auth_logout, name="logout"),

--- a/azure_auth/urls.py
+++ b/azure_auth/urls.py
@@ -1,10 +1,18 @@
 from django.urls import path
 
-from azure_auth.views import azure_auth_callback, azure_auth_login, azure_auth_logout
+from azure_auth.views import (
+    azure_auth_callback,
+    azure_auth_login,
+    azure_auth_logout,
+    wam_auth_login,
+)
+from azure_auth.utils import is_broker_enabled
 
 app_name = "azure_auth"
+
+_login_function = azure_auth_login if not is_broker_enabled() else wam_auth_login
 urlpatterns = [
-    path("login", azure_auth_login, name="login"),
+    path("login", _login_function, name="login"),
     path("logout", azure_auth_logout, name="logout"),
     path("callback", azure_auth_callback, name="callback"),
 ]

--- a/azure_auth/utils.py
+++ b/azure_auth/utils.py
@@ -1,4 +1,7 @@
 import json
+from typing import Any
+
+from django.conf import settings
 
 
 class EntraStateSerializer:
@@ -10,3 +13,30 @@ class EntraStateSerializer:
             return json.loads(state)
         except json.JSONDecodeError:
             return {}
+
+
+def enable_broker_on_windows(azure_auth: dict[str, Any]) -> None:
+    """
+    Modifies the given azure_auth settings dictionary to enable brokered authentication.
+    This assumes the current platform is Windows.
+
+    For details, see:
+        Using MSAL Python with Web Account Manager
+        https://learn.microsoft.com/en-us/entra/msal/python/advanced/wam
+    """
+
+    # WAM only makes sense for public clients.  The Azure Portal also needs to have
+    # the correct redirect URL configured:
+    #   ms-appx-web://microsoft.aad.brokerplugin/YOUR_CLIENT_ID
+    azure_auth["CLIENT_TYPE"] = "public_client"
+    additional_client_kwargs = azure_auth.get("ADDITIONAL_CLIENT_KWARGS", {})
+    additional_client_kwargs["enable_broker_on_windows"] = True
+    azure_auth["ADDITIONAL_CLIENT_KWARGS"] = additional_client_kwargs
+
+
+def is_broker_enabled() -> bool:
+    """Returns True if brokered authentication is enabled in the settings,
+    False otherwise."""
+    return settings.AZURE_AUTH.get("ADDITIONAL_CLIENT_KWARGS", {}).get(
+        "enable_broker_on_windows", False
+    )

--- a/azure_auth/utils.py
+++ b/azure_auth/utils.py
@@ -1,8 +1,6 @@
 import json
 from typing import Any
 
-from django.conf import settings
-
 
 class EntraStateSerializer:
     def serialize(self, **kwargs):
@@ -34,9 +32,9 @@ def enable_broker_on_windows(azure_auth: dict[str, Any]) -> None:
     azure_auth["ADDITIONAL_CLIENT_KWARGS"] = additional_client_kwargs
 
 
-def is_broker_enabled() -> bool:
-    """Returns True if brokered authentication is enabled in the settings,
+def is_broker_enabled(azure_auth: dict[str, Any]) -> bool:
+    """Returns True if brokered authentication is enabled in the given settings,
     False otherwise."""
-    return settings.AZURE_AUTH.get("ADDITIONAL_CLIENT_KWARGS", {}).get(
+    return azure_auth.get("ADDITIONAL_CLIENT_KWARGS", {}).get(
         "enable_broker_on_windows", False
     )

--- a/azure_auth/views.py
+++ b/azure_auth/views.py
@@ -42,3 +42,23 @@ def azure_auth_callback(request: HttpRequest):
             return HttpResponseRedirect(next)
         return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL)
     return HttpResponseForbidden("Invalid email for this app.")
+
+
+def wam_auth_login(request: HttpRequest):
+    """
+    This view is used to handle Windows Authentication Manager (WAM) login.
+    """
+    # WAM flow is synchrous, so we get a token immediately
+    token = AuthHandler(request).wam_login()
+    if not token:
+        return HttpResponseForbidden("WAM login failed.")
+
+    user = authenticate(request, token=token)
+    if user:
+        login(request, user)
+
+        next = request.GET.get("next")
+        if next and url_has_allowed_host_and_scheme(next, allowed_hosts=None):
+            return HttpResponseRedirect(next)
+        return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL)
+    return HttpResponseForbidden("Invalid email for this app.")

--- a/azure_auth/views.py
+++ b/azure_auth/views.py
@@ -48,7 +48,8 @@ def wam_auth_login(request: HttpRequest):
     """
     This view is used to handle Windows Authentication Manager (WAM) login.
     """
-    # WAM flow is synchrous, so we get a token immediately
+    # WAM flow is synchrous, so we get a token immediately.  Hence this function
+    # also includes the callback logic.
     token = AuthHandler(request).wam_login()
     if not token:
         return HttpResponseForbidden("WAM login failed.")


### PR DESCRIPTION
Public Client apps can (optionally) be configured to support Web Account Manager (WAM) on Windows platforms.

This PR adds support for this, by:
 * Add new helper to configure AZURE_AUTH consistently for broker login (`enable_broker_on_windows()`)
 * Add new `wam_auth_login()` authentication handler
 * Use this new handler as the `azure_auth:login` URL handler, if the AZURE_AUTH config is asking for broker login.
 