### PR TITLE
Handle absent role claim

### DIFF
--- a/azure_auth/handlers.py
+++ b/azure_auth/handlers.py
@@ -139,7 +139,7 @@ class AuthHandler:
         self.initialize_groups()
 
         groups_attr = settings.AZURE_AUTH.get("GROUP_ATTRIBUTE", "roles")
-        azure_token_roles = token.get("id_token_claims", {}).get(groups_attr, None)
+        azure_token_roles = token.get("id_token_claims", {}).get(groups_attr, [])
 
         token_groups = set()
         all_groups = set()


### PR DESCRIPTION
`if role_id in azure_token_roles:` assumes `azure_token_roles` is not None. With a default value of [] rather than None, the function handles tokens both with and without role claims. 