### PR TITLE
Improvement/add logic to set user flags based on roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ AZURE_AUTH = {
         "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": "GroupName1", # mapped to one Django group
         "3dc6539e-0589-4663-b782-fef100d839aa": ["GroupName2", "GroupName3"] # mapped to multiple Django groups
     },  # Optional, will add user to django group if user is in EntraID group
+    "ROLE_TO_FLAG_MAPPING": {
+        "my_cool_role_1": [ "is_staff", ], # gives users having this role access to the django admin GUI
+        "my_admin_role": ["is_superuser", "is_staff"], # makes users having this role superusers
+    }, # Optional, will set user model flags based on roles
     "USERNAME_ATTRIBUTE": "mail",   # The AAD attribute or ID token claim you want to use as the value for the user model `USERNAME_FIELD`
     "GROUP_ATTRIBUTE": "roles",   # The AAD attribute or ID token claim you want to use as the value for the user's group memberships
     "EXTRA_FIELDS": [], # Optional, extra AAD user profile attributes you want to make available in the user mapping function

--- a/azure_auth/handlers.py
+++ b/azure_auth/handlers.py
@@ -1,5 +1,6 @@
 import datetime
 import importlib
+import logging
 from http import HTTPStatus
 from typing import Optional, cast
 from urllib import parse
@@ -29,9 +30,7 @@ class AuthHandler:
         :param request: HttpRequest
         """
         self.request = request
-        self.graph_user_endpoint = settings.AZURE_AUTH.get(
-            "GRAPH_USER_ENDPOINT", "https://graph.microsoft.com/v1.0/me"
-        )
+        self.graph_user_endpoint = settings.AZURE_AUTH.get("GRAPH_USER_ENDPOINT", "https://graph.microsoft.com/v1.0/me")
         self.auth_flow_session_key = "auth_flow"
         self._cache = msal.SerializableTokenCache()
         self._msal_app = None
@@ -66,9 +65,7 @@ class AuthHandler:
         claims, depending on scopes used
         """
         flow = self.request.session.pop(self.auth_flow_session_key, {})
-        token_result = self.msal_app.acquire_token_by_auth_code_flow(
-            auth_code_flow=flow, auth_response=self.request.GET
-        )
+        token_result = self.msal_app.acquire_token_by_auth_code_flow(auth_code_flow=flow, auth_response=self.request.GET)
         if "error" in token_result:
             raise TokenError(token_result["error"], token_result["error_description"])
         self._save_cache()
@@ -79,17 +76,13 @@ class AuthHandler:
         accounts = self.msal_app.get_accounts()
         if accounts:  # pragma: no branch
             # Will return `None` if CCA cannot retrieve or generate new token
-            token_result = self.msal_app.acquire_token_silent(
-                scopes=settings.AZURE_AUTH["SCOPES"], account=accounts[0]
-            )
+            token_result = self.msal_app.acquire_token_silent(scopes=settings.AZURE_AUTH["SCOPES"], account=accounts[0])
             self._save_cache()
 
             # `acquire_token_silent` doesn't always return ID token/ID token claims
             # https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/139
             if token_result and token_result.get("id_token_claims"):
-                self.request.session["id_token_claims"] = token_result[
-                    "id_token_claims"
-                ]
+                self.request.session["id_token_claims"] = token_result["id_token_claims"]
             return token_result
 
     def authenticate(self, token: dict) -> AbstractBaseUser:
@@ -123,7 +116,8 @@ class AuthHandler:
                 **self._map_attributes_to_user(**attributes),
             )
 
-        user = self.sync_groups(user, token)
+        user, azure_token_roles = self.sync_groups(user, token)
+        user = self.sync_user_flags(user, token, azure_token_roles)
 
         return user
 
@@ -131,7 +125,7 @@ class AuthHandler:
     # A role mapping in the AZURE_AUTH settings is expected.
     # The attribute of the token to use for group membership can be specified
     #   in AZURE_AUTH.GROUP_ATTRIBUTE
-    def sync_groups(self, user, token):
+    def sync_groups(self, user, token) -> (AbstractBaseUser, dict):
         role_mappings = settings.AZURE_AUTH.get("ROLES")
         if not role_mappings:
             # No role mappings defined, nothing to do
@@ -139,7 +133,7 @@ class AuthHandler:
         self.initialize_groups()
 
         groups_attr = settings.AZURE_AUTH.get("GROUP_ATTRIBUTE", "roles")
-        azure_token_roles = token.get("id_token_claims", {}).get(groups_attr, None)
+        azure_token_roles = token.get("id_token_claims", {}).get(groups_attr, [])
 
         token_groups = set()
         all_groups = set()
@@ -154,13 +148,9 @@ class AuthHandler:
         if to_add := [item for item in token_groups if item not in current_groups]:
             user.groups.add(*Group.objects.filter(name__in=to_add))
 
-        if to_remove := [
-            item
-            for item in current_groups
-            if item in all_groups and item not in token_groups
-        ]:
+        if to_remove := [item for item in current_groups if item in all_groups and item not in token_groups]:
             user.groups.remove(*Group.objects.filter(name__in=to_remove))
-        return user
+        return user, azure_token_roles
 
     def initialize_groups(self):
         if not AuthHandler.GROUPS_UPDATED:
@@ -175,6 +165,36 @@ class AuthHandler:
                     if group_name:
                         Group.objects.get_or_create(name=group_name)
         AuthHandler.GROUPS_UPDATED = True
+
+    def sync_user_flags(self, user: AbstractBaseUser, token: dict, azure_token_roles: dict) -> AbstractBaseUser:
+        """
+        Syncs user flags such as is_staff and is_superuser based on token claims.
+
+        :param user: Django user instance
+        :param token: MSAL auth token dictionary
+        :param azure_token_roles: azure token roles extracted from the token in sync_groups()
+        :return: Updated Django user instance
+        """
+        logger = logging.getLogger("django-azure-auth.handlers")
+
+        # the role to flag mapping allows setting is_superuser and is_staff based on roles
+        for role_to_map in settings.AZURE_AUTH.get("ROLE_TO_FLAG_MAPPING", {}).keys():
+            if role_to_map in azure_token_roles:
+                logger.info(f'Role "{role_to_map}" found for user "{user}"...')
+                for flag_name in ["is_superuser", "is_staff"]:
+                    if hasattr(user, flag_name):
+                        if flag_name in settings.AZURE_AUTH.get("ROLE_TO_FLAG_MAPPING", {}).get(role_to_map, []):
+                            logger.info(f'Setting user "{user}" flag "{flag_name}" to true based on role "{role_to_map}"...')
+                            setattr(user, flag_name, True)
+                            user.save()
+                        else:
+                            logger.debug(f'No mapping for flag "{flag_name}" for role "{role_to_map}"...')
+                            setattr(user, flag_name, False)
+                            user.save()
+                    else:
+                        logger.warning(f'User model does not have a flag "{flag_name}" to set for role "{role_to_map}"!')
+
+        return user
 
     def get_logout_uri(self) -> str:
         """
@@ -200,17 +220,12 @@ class AuthHandler:
             return True
 
         # Otherwise try refresh the token
-        return (
-            self.get_token_from_cache() is not None
-            and self.request.user.is_authenticated
-        )
+        return self.get_token_from_cache() is not None and self.request.user.is_authenticated
 
     def _get_confidential_client(self):
         secret = settings.AZURE_AUTH.get("CLIENT_SECRET", "<client_secret>")
         if secret == "<client_secret>":
-            raise DjangoAzureAuthException(
-                "CLIENT_TYPE='confidential_client' also requires CLIENT_SECRET to be set in AZURE_AUTH"
-            )
+            raise DjangoAzureAuthException("CLIENT_TYPE='confidential_client' also requires CLIENT_SECRET to be set in AZURE_AUTH")
         additional_kwargs = settings.AZURE_AUTH.get("ADDITIONAL_CLIENT_KWARGS", {})
         return msal.ConfidentialClientApplication(
             client_id=settings.AZURE_AUTH["CLIENT_ID"],
@@ -238,9 +253,7 @@ class AuthHandler:
             elif client_type == "public_client":
                 self._msal_app = self._get_public_client()
             else:
-                raise DjangoAzureAuthException(
-                    f"Invalid CLIENT_TYPE '{client_type}' specified in AZURE_AUTH settings."
-                )
+                raise DjangoAzureAuthException(f"Invalid CLIENT_TYPE '{client_type}' specified in AZURE_AUTH settings.")
         return self._msal_app
 
     @property
@@ -269,9 +282,7 @@ class AuthHandler:
             raise DjangoAzureAuthException("An unknown error occurred.")
 
     def _map_attributes_to_user(self, **fields) -> dict:
-        if user_mapping_fn := settings.AZURE_AUTH.get(
-            "USER_MAPPING_FN"
-        ):  # pragma: no branch
+        if user_mapping_fn := settings.AZURE_AUTH.get("USER_MAPPING_FN"):  # pragma: no branch
             path, fn = user_mapping_fn.rsplit(".", 1)
             mod = importlib.import_module(path)
             return getattr(mod, fn)(**fields)

--- a/azure_auth/tests/test_handler.py
+++ b/azure_auth/tests/test_handler.py
@@ -29,13 +29,21 @@ class TestAzureAuthHandler(TestCase):
         redirect_uri = handler._get_redirect_uri()
         self.assertEqual(redirect_uri, "http://testserver/azure_auth/callback_absolut")
 
-    @override_settings(AZURE_AUTH=ChainMap({"REDIRECT_URI": "/azure_auth/callback_relative"}, settings.AZURE_AUTH))
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {"REDIRECT_URI": "/azure_auth/callback_relative"}, settings.AZURE_AUTH
+        )
+    )
     def test_callback_uri_relative(self):
         handler = self._build_auth_handler()
         redirect_uri = handler._get_redirect_uri()
         self.assertEqual(redirect_uri, "http://testserver/azure_auth/callback_relative")
 
-    @override_settings(AZURE_AUTH=ChainMap({"REDIRECT_URI": reverse_lazy("decorator_protected")}, settings.AZURE_AUTH))
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {"REDIRECT_URI": reverse_lazy("decorator_protected")}, settings.AZURE_AUTH
+        )
+    )
     def test_callback_uri_reverse_lazy(self):
         handler = self._build_auth_handler()
         redirect_uri = handler._get_redirect_uri()
@@ -176,7 +184,10 @@ class TestAzureAuthHandler(TestCase):
         AZURE_AUTH=ChainMap(
             {
                 "ROLE_TO_FLAG_MAPPING": {
-                    "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": ["is_staff", "is_superuser"],
+                    "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": [
+                        "is_staff",
+                        "is_superuser",
+                    ],
                 }
             },
             settings.AZURE_AUTH,


### PR DESCRIPTION
Hi Armand,

as discussed: Here is the pull request to add the functionality to set user flags (e.g. is_staff, is_superuser) to django_azure_auth.
I have

- added the logic to handlers.py
- updated the README.md to show the new setting in the django settings.py example
- added two tests to test_handlers.py to test the new method sync_user_flags()

Reason for this pull request: Based on roles set by M365 entra ID in the JWT id_token claims I want to give a user access to the django admin panel (requires is_staff to be set to True for the user) or I even want to make him/her a superuser (which requires both is_staff and is_superuser to be set to True for the user).

Last commit: Reformatted with line length 88 to keep the existing formatting so that "files changed" does not show formatting changes

Thx...