### PR TITLE
Improvement/add logic if user read scope not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ AZURE_AUTH = {
     # - a relative URI starting with "/", e. g. /azure_auth/callback
     # - a call to reverse_lazy, e. g. reverse_lazy("azure_auth:callback")
     "REDIRECT_URI": "https://<domain>/azure_auth/callback",
+    # Some enterprise Entra ID setups do not permit a User.Read scope for security reasons
+    # in this case set the SCOPES to an empty list (we will the skip reading the User s profile) 
+    # and make sure your ID token contains the required claims for mapping them to 
+    # the django user fields
     "SCOPES": ["User.Read"],
     "PROMPT": "select_account",  # Optional, one of "login", "consent", "select_account", "none" (default)
     #"ADDITIONAL_CLIENT_KWARGS": {"enable_broker_on_windows": True}, # Optional: additional KWARGS to give to public and confidential client

--- a/azure_auth/handlers.py
+++ b/azure_auth/handlers.py
@@ -29,9 +29,7 @@ class AuthHandler:
         :param request: HttpRequest
         """
         self.request = request
-        self.graph_user_endpoint = settings.AZURE_AUTH.get(
-            "GRAPH_USER_ENDPOINT", "https://graph.microsoft.com/v1.0/me"
-        )
+        self.graph_user_endpoint = settings.AZURE_AUTH.get("GRAPH_USER_ENDPOINT", "https://graph.microsoft.com/v1.0/me")
         self.auth_flow_session_key = "auth_flow"
         self._cache = msal.SerializableTokenCache()
         self._msal_app = None
@@ -66,9 +64,7 @@ class AuthHandler:
         claims, depending on scopes used
         """
         flow = self.request.session.pop(self.auth_flow_session_key, {})
-        token_result = self.msal_app.acquire_token_by_auth_code_flow(
-            auth_code_flow=flow, auth_response=self.request.GET
-        )
+        token_result = self.msal_app.acquire_token_by_auth_code_flow(auth_code_flow=flow, auth_response=self.request.GET)
         if "error" in token_result:
             raise TokenError(token_result["error"], token_result["error_description"])
         self._save_cache()
@@ -79,17 +75,13 @@ class AuthHandler:
         accounts = self.msal_app.get_accounts()
         if accounts:  # pragma: no branch
             # Will return `None` if CCA cannot retrieve or generate new token
-            token_result = self.msal_app.acquire_token_silent(
-                scopes=settings.AZURE_AUTH["SCOPES"], account=accounts[0]
-            )
+            token_result = self.msal_app.acquire_token_silent(scopes=settings.AZURE_AUTH["SCOPES"], account=accounts[0])
             self._save_cache()
 
             # `acquire_token_silent` doesn't always return ID token/ID token claims
             # https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/139
             if token_result and token_result.get("id_token_claims"):
-                self.request.session["id_token_claims"] = token_result[
-                    "id_token_claims"
-                ]
+                self.request.session["id_token_claims"] = token_result["id_token_claims"]
             return token_result
 
     def authenticate(self, token: dict) -> AbstractBaseUser:
@@ -100,11 +92,19 @@ class AuthHandler:
         :param token: MSAL auth token dictionary
         :return: Django user instance
         """
-        azure_user = self._get_azure_user(token["access_token"])
+        # Some enterprise Entra ID setups do not permit a User.Read scope for security reasons
+        # in this case we skip the user profile request and expect all required attributes to be
+        # available in the ID token claims
+        if "User.Read" in settings.AZURE_AUTH.get("SCOPES", []):
+            azure_user = self._get_azure_user(token["access_token"])
+        else:
+            azure_user = {}
 
         # Get extra fields
         extra_fields = {}
         if fields := settings.AZURE_AUTH.get("EXTRA_FIELDS"):  # pragma: no branch
+            if "User.Read" not in settings.AZURE_AUTH.get("SCOPES", []):
+                raise DjangoAzureAuthException("EXTRA_FIELDS requires 'User.Read' scope to be set in AZURE_AUTH.SCOPES!")
             extra_fields = self._get_azure_user(token["access_token"], fields=fields)
 
         # Combine user profile attributes, extra attributes and ID token claims
@@ -154,11 +154,7 @@ class AuthHandler:
         if to_add := [item for item in token_groups if item not in current_groups]:
             user.groups.add(*Group.objects.filter(name__in=to_add))
 
-        if to_remove := [
-            item
-            for item in current_groups
-            if item in all_groups and item not in token_groups
-        ]:
+        if to_remove := [item for item in current_groups if item in all_groups and item not in token_groups]:
             user.groups.remove(*Group.objects.filter(name__in=to_remove))
         return user
 
@@ -200,17 +196,12 @@ class AuthHandler:
             return True
 
         # Otherwise try refresh the token
-        return (
-            self.get_token_from_cache() is not None
-            and self.request.user.is_authenticated
-        )
+        return self.get_token_from_cache() is not None and self.request.user.is_authenticated
 
     def _get_confidential_client(self):
         secret = settings.AZURE_AUTH.get("CLIENT_SECRET", "<client_secret>")
         if secret == "<client_secret>":
-            raise DjangoAzureAuthException(
-                "CLIENT_TYPE='confidential_client' also requires CLIENT_SECRET to be set in AZURE_AUTH"
-            )
+            raise DjangoAzureAuthException("CLIENT_TYPE='confidential_client' also requires CLIENT_SECRET to be set in AZURE_AUTH")
         additional_kwargs = settings.AZURE_AUTH.get("ADDITIONAL_CLIENT_KWARGS", {})
         return msal.ConfidentialClientApplication(
             client_id=settings.AZURE_AUTH["CLIENT_ID"],
@@ -238,9 +229,7 @@ class AuthHandler:
             elif client_type == "public_client":
                 self._msal_app = self._get_public_client()
             else:
-                raise DjangoAzureAuthException(
-                    f"Invalid CLIENT_TYPE '{client_type}' specified in AZURE_AUTH settings."
-                )
+                raise DjangoAzureAuthException(f"Invalid CLIENT_TYPE '{client_type}' specified in AZURE_AUTH settings.")
         return self._msal_app
 
     @property
@@ -269,9 +258,7 @@ class AuthHandler:
             raise DjangoAzureAuthException("An unknown error occurred.")
 
     def _map_attributes_to_user(self, **fields) -> dict:
-        if user_mapping_fn := settings.AZURE_AUTH.get(
-            "USER_MAPPING_FN"
-        ):  # pragma: no branch
+        if user_mapping_fn := settings.AZURE_AUTH.get("USER_MAPPING_FN"):  # pragma: no branch
             path, fn = user_mapping_fn.rsplit(".", 1)
             mod = importlib.import_module(path)
             return getattr(mod, fn)(**fields)

--- a/azure_auth/handlers.py
+++ b/azure_auth/handlers.py
@@ -29,7 +29,9 @@ class AuthHandler:
         :param request: HttpRequest
         """
         self.request = request
-        self.graph_user_endpoint = settings.AZURE_AUTH.get("GRAPH_USER_ENDPOINT", "https://graph.microsoft.com/v1.0/me")
+        self.graph_user_endpoint = settings.AZURE_AUTH.get(
+            "GRAPH_USER_ENDPOINT", "https://graph.microsoft.com/v1.0/me"
+        )
         self.auth_flow_session_key = "auth_flow"
         self._cache = msal.SerializableTokenCache()
         self._msal_app = None
@@ -64,7 +66,9 @@ class AuthHandler:
         claims, depending on scopes used
         """
         flow = self.request.session.pop(self.auth_flow_session_key, {})
-        token_result = self.msal_app.acquire_token_by_auth_code_flow(auth_code_flow=flow, auth_response=self.request.GET)
+        token_result = self.msal_app.acquire_token_by_auth_code_flow(
+            auth_code_flow=flow, auth_response=self.request.GET
+        )
         if "error" in token_result:
             raise TokenError(token_result["error"], token_result["error_description"])
         self._save_cache()
@@ -75,13 +79,17 @@ class AuthHandler:
         accounts = self.msal_app.get_accounts()
         if accounts:  # pragma: no branch
             # Will return `None` if CCA cannot retrieve or generate new token
-            token_result = self.msal_app.acquire_token_silent(scopes=settings.AZURE_AUTH["SCOPES"], account=accounts[0])
+            token_result = self.msal_app.acquire_token_silent(
+                scopes=settings.AZURE_AUTH["SCOPES"], account=accounts[0]
+            )
             self._save_cache()
 
             # `acquire_token_silent` doesn't always return ID token/ID token claims
             # https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/139
             if token_result and token_result.get("id_token_claims"):
-                self.request.session["id_token_claims"] = token_result["id_token_claims"]
+                self.request.session["id_token_claims"] = token_result[
+                    "id_token_claims"
+                ]
             return token_result
 
     def authenticate(self, token: dict) -> AbstractBaseUser:
@@ -104,7 +112,9 @@ class AuthHandler:
         extra_fields = {}
         if fields := settings.AZURE_AUTH.get("EXTRA_FIELDS"):  # pragma: no branch
             if "User.Read" not in settings.AZURE_AUTH.get("SCOPES", []):
-                raise DjangoAzureAuthException("EXTRA_FIELDS requires 'User.Read' scope to be set in AZURE_AUTH.SCOPES!")
+                raise DjangoAzureAuthException(
+                    "EXTRA_FIELDS requires 'User.Read' scope to be set in AZURE_AUTH.SCOPES!"
+                )
             extra_fields = self._get_azure_user(token["access_token"], fields=fields)
 
         # Combine user profile attributes, extra attributes and ID token claims
@@ -154,7 +164,11 @@ class AuthHandler:
         if to_add := [item for item in token_groups if item not in current_groups]:
             user.groups.add(*Group.objects.filter(name__in=to_add))
 
-        if to_remove := [item for item in current_groups if item in all_groups and item not in token_groups]:
+        if to_remove := [
+            item
+            for item in current_groups
+            if item in all_groups and item not in token_groups
+        ]:
             user.groups.remove(*Group.objects.filter(name__in=to_remove))
         return user
 
@@ -196,12 +210,17 @@ class AuthHandler:
             return True
 
         # Otherwise try refresh the token
-        return self.get_token_from_cache() is not None and self.request.user.is_authenticated
+        return (
+            self.get_token_from_cache() is not None
+            and self.request.user.is_authenticated
+        )
 
     def _get_confidential_client(self):
         secret = settings.AZURE_AUTH.get("CLIENT_SECRET", "<client_secret>")
         if secret == "<client_secret>":
-            raise DjangoAzureAuthException("CLIENT_TYPE='confidential_client' also requires CLIENT_SECRET to be set in AZURE_AUTH")
+            raise DjangoAzureAuthException(
+                "CLIENT_TYPE='confidential_client' also requires CLIENT_SECRET to be set in AZURE_AUTH"
+            )
         additional_kwargs = settings.AZURE_AUTH.get("ADDITIONAL_CLIENT_KWARGS", {})
         return msal.ConfidentialClientApplication(
             client_id=settings.AZURE_AUTH["CLIENT_ID"],
@@ -229,7 +248,9 @@ class AuthHandler:
             elif client_type == "public_client":
                 self._msal_app = self._get_public_client()
             else:
-                raise DjangoAzureAuthException(f"Invalid CLIENT_TYPE '{client_type}' specified in AZURE_AUTH settings.")
+                raise DjangoAzureAuthException(
+                    f"Invalid CLIENT_TYPE '{client_type}' specified in AZURE_AUTH settings."
+                )
         return self._msal_app
 
     @property
@@ -258,7 +279,9 @@ class AuthHandler:
             raise DjangoAzureAuthException("An unknown error occurred.")
 
     def _map_attributes_to_user(self, **fields) -> dict:
-        if user_mapping_fn := settings.AZURE_AUTH.get("USER_MAPPING_FN"):  # pragma: no branch
+        if user_mapping_fn := settings.AZURE_AUTH.get(
+            "USER_MAPPING_FN"
+        ):  # pragma: no branch
             path, fn = user_mapping_fn.rsplit(".", 1)
             mod = importlib.import_module(path)
             return getattr(mod, fn)(**fields)

--- a/azure_auth/tests/test_handler.py
+++ b/azure_auth/tests/test_handler.py
@@ -28,13 +28,21 @@ class TestAzureAuthHandler(TestCase):
         redirect_uri = handler._get_redirect_uri()
         self.assertEqual(redirect_uri, "http://testserver/azure_auth/callback_absolut")
 
-    @override_settings(AZURE_AUTH=ChainMap({"REDIRECT_URI": "/azure_auth/callback_relative"}, settings.AZURE_AUTH))
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {"REDIRECT_URI": "/azure_auth/callback_relative"}, settings.AZURE_AUTH
+        )
+    )
     def test_callback_uri_relative(self):
         handler = self._build_auth_handler()
         redirect_uri = handler._get_redirect_uri()
         self.assertEqual(redirect_uri, "http://testserver/azure_auth/callback_relative")
 
-    @override_settings(AZURE_AUTH=ChainMap({"REDIRECT_URI": reverse_lazy("decorator_protected")}, settings.AZURE_AUTH))
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {"REDIRECT_URI": reverse_lazy("decorator_protected")}, settings.AZURE_AUTH
+        )
+    )
     def test_callback_uri_reverse_lazy(self):
         handler = self._build_auth_handler()
         redirect_uri = handler._get_redirect_uri()
@@ -171,39 +179,69 @@ class TestAzureAuthHandler(TestCase):
         handler.sync_groups(self.user, self.token)
         self.assertEqual(self.user.groups.count(), 3)
 
-    @override_settings(AZURE_AUTH=ChainMap({"SCOPES": ["User.Read"], "USERNAME_ATTRIBUTE": "mail"}, settings.AZURE_AUTH))
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {"SCOPES": ["User.Read"], "USERNAME_ATTRIBUTE": "mail"}, settings.AZURE_AUTH
+        )
+    )
     def test_authenticate_with_user_read_scope(self):
         from unittest.mock import patch, MagicMock
 
         handler = self._build_auth_handler()
         dummy_user = MagicMock()
-        dummy_token = {"access_token": "dummy", "id_token_claims": {"mail": "blah", "roles": []}}
+        dummy_token = {
+            "access_token": "dummy",
+            "id_token_claims": {"mail": "blah", "roles": []},
+        }
         with (
-            patch.object(handler, "_get_azure_user", return_value={"username": "testuser"}),
+            patch.object(
+                handler, "_get_azure_user", return_value={"username": "testuser"}
+            ),
             patch.object(handler, "_update_user", return_value=None),
-            patch.object(handler, "_map_attributes_to_user", return_value={"username": "testuser"}),
+            patch.object(
+                handler,
+                "_map_attributes_to_user",
+                return_value={"username": "testuser"},
+            ),
             patch.object(handler, "sync_groups", return_value=dummy_user),
         ):
             # Patch UserModel._default_manager.get_by_natural_key to return dummy_user
-            with patch("azure_auth.handlers.UserModel._default_manager.get_by_natural_key", return_value=dummy_user):
+            with patch(
+                "azure_auth.handlers.UserModel._default_manager.get_by_natural_key",
+                return_value=dummy_user,
+            ):
                 result = handler.authenticate(dummy_token)
         self.assertEqual(result, dummy_user)
 
-    @override_settings(AZURE_AUTH=ChainMap({"SCOPES": [], "USERNAME_ATTRIBUTE": "mail"}, settings.AZURE_AUTH))
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {"SCOPES": [], "USERNAME_ATTRIBUTE": "mail"}, settings.AZURE_AUTH
+        )
+    )
     def test_authenticate_without_user_read_scope(self):
         from unittest.mock import patch, MagicMock
 
         handler = self._build_auth_handler()
         dummy_user = MagicMock()
-        dummy_token = {"access_token": "dummy", "id_token_claims": {"mail": "blah", "roles": []}}
+        dummy_token = {
+            "access_token": "dummy",
+            "id_token_claims": {"mail": "blah", "roles": []},
+        }
         with (
             patch.object(handler, "_get_azure_user") as mock_get_azure_user,
             patch.object(handler, "_update_user", return_value=None),
-            patch.object(handler, "_map_attributes_to_user", return_value={"username": "testuser"}),
+            patch.object(
+                handler,
+                "_map_attributes_to_user",
+                return_value={"username": "testuser"},
+            ),
             patch.object(handler, "sync_groups", return_value=dummy_user),
         ):
             # Patch UserModel._default_manager.get_by_natural_key to return dummy_user
-            with patch("azure_auth.handlers.UserModel._default_manager.get_by_natural_key", return_value=dummy_user):
+            with patch(
+                "azure_auth.handlers.UserModel._default_manager.get_by_natural_key",
+                return_value=dummy_user,
+            ):
                 result = handler.authenticate(dummy_token)
         self.assertEqual(result, dummy_user)
         mock_get_azure_user.assert_not_called()


### PR DESCRIPTION
Hi Armand,

as discussed: Here is the pull request to add the functionality to skip calling the 

- added the logic to handlers.py
- added two tests to test_handlers.py to test whether setting SCOPES to [] then triggers skipping the call to the _get_azure_user() method (which apparently requires the "User.Read" scope since it apparently reads the user s profile.

Reason for this pull request: For (unknown to me) security reasons our company no longer gives us the "User.Read" permission when registering an application for SSO / OIDC in the MS Entra ID registration.

Last commit: Reformatted with line length 88 to keep the existing formatting so that "files changed" does not show formatting changes

Thx...